### PR TITLE
Throw a readable error when baseFetch fails

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -134,26 +134,21 @@ function createCache(conf: Doc): Doc {
 }
 
 /** Base fetch. */
-function baseFetch(conf: Doc, op: string, params: Doc): Promise<Doc> {
+async function baseFetch(conf: Doc, op: string, params: Doc): Promise<Doc> {
   const payload: Uint8Array = encode(JSON.stringify(params), "utf8");
 
   const headers: Headers = createHeaders(op, payload, conf as HeadersConfig);
 
-  return fetch(conf.endpoint, {
+  const response: Response = await fetch(conf.endpoint, {
     method: conf.method,
     headers,
     body: payload
-  }).then(
-    (response: Response): Doc => {
-      if (!response.ok) {
-        throw new Error(
-          `http query request failed: ${response.status} ${response.statusText}`
-        );
-      }
-
-      return response.json();
-    }
-  );
+  });
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(body.message);
+  }
+  return body;
 }
 
 /** Base op. */


### PR DESCRIPTION
This makes debugging issues much easier.

Potentially a more specific error could be thrown (not just `Error`).

I'm not sure if I can trigger any other cases e.g. 500,  or if it does't return json body,  I think they would raise anyhow...