### PR TITLE
Add support for AWS_SESSION_TOKEN temporary credentials

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -29,6 +29,7 @@ export interface ClientConfig {
   region: string; // us-west-2
   canonicalUri?: string; // fx /path/to/somewhere
   port?: number; // 8000
+  sessionToken?: () => string | Promise<string>;
 }
 
 /** Op options. */
@@ -137,7 +138,7 @@ function createCache(conf: Doc): Doc {
 async function baseFetch(conf: Doc, op: string, params: Doc): Promise<Doc> {
   const payload: Uint8Array = encode(JSON.stringify(params), "utf8");
 
-  const headers: Headers = createHeaders(op, payload, conf as HeadersConfig);
+  const headers: Headers = await createHeaders(op, payload, conf as HeadersConfig);
 
   const response: Response = await fetch(conf.endpoint, {
     method: conf.method,

--- a/test.ts
+++ b/test.ts
@@ -432,4 +432,20 @@ test({
   }
 });
 
+test({
+  name: "test security token can be passed",
+  async fn(): Promise<void> {
+    // currently there's no way to test this is appended to the header
+    // but we include it in the ClientConfig.
+    const conf: ClientConfig = {
+      accessKeyId: ENV.ACCESS_KEY_ID,
+      secretAccessKey: ENV.SECRET_ACCESS_KEY,
+      region: "local",
+      sessionToken: () => "test"
+    };
+    const ddbc: DynamoDBClient = createClient(conf);
+    const result: Doc = await ddbc.listTables();
+  }
+});
+
 runIfMain(import.meta);


### PR DESCRIPTION
Fixes #1. As mentioned this is required for AWS Lambda support.

Note: There might be a better way to include this, specifically if env access should not be required we could `try` to do this once and if there's a AWS_SESSION_TOKEN only then refresh it each request (otherwise do not try/add the header).

cc https://github.com/hayd/deno-lambda/pull/14/