### PR TITLE
scan and query always return AsyncIterators

### DIFF
--- a/client/mod.ts
+++ b/client/mod.ts
@@ -1,5 +1,5 @@
 export { awsSignatureV4 } from "./aws_signature_v4.ts";
-export { baseOp } from "./base_op.ts";
+export { baseOp, baseOpIterator } from "./base_op.ts";
 export { deriveConfig } from "./derive_config.ts";
 export { HeadersConfig, createHeaders } from "./create_headers.ts";
 export { Translator } from "./translator.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { baseOp, deriveConfig } from "./client/mod.ts";
+import { baseOp, baseOpIterator, deriveConfig } from "./client/mod.ts";
 import { Doc, camelCase } from "./util.ts";
 
 /** Convenience export. */
@@ -12,12 +12,42 @@ export interface DynamoDBClient {
   scan: (
     params: Doc,
     options?: Doc
-  ) => Promise<Doc | AsyncIterableIterator<Doc>>;
+  ) => AsyncIterable<Doc>;
   query: (
     params: Doc,
     options?: Doc
-  ) => Promise<Doc | AsyncIterableIterator<Doc>>;
-  [key: string]: (params: Doc, options?: Doc) => Promise<Doc>;
+  ) => AsyncIterable<Doc>;
+  batchGetItem: (params: Doc, options?: Doc) => Promise<Doc>;
+  batchWriteItem: (params: Doc, options?: Doc) => Promise<Doc>;
+  createBackup: (params: Doc, options?: Doc) => Promise<Doc>;
+  createGlobalTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  createTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  deleteBackup: (params: Doc, options?: Doc) => Promise<Doc>;
+  deleteItem: (params: Doc, options?: Doc) => Promise<Doc>;
+  deleteTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  describeBackup: (params: Doc, options?: Doc) => Promise<Doc>;
+  describeContinuousBackups: (params: Doc, options?: Doc) => Promise<Doc>;
+  describeGlobalTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  describeGlobalTableSettings: (params: Doc, options?: Doc) => Promise<Doc>;
+  describeTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  describeTimeToLive: (params: Doc, options?: Doc) => Promise<Doc>;
+  getItem: (params: Doc, options?: Doc) => Promise<Doc>;
+  listBackups: (params: Doc, options?: Doc) => Promise<Doc>;
+  listGlobalTables: (params: Doc, options?: Doc) => Promise<Doc>;
+  listTagsOfResource: (params: Doc, options?: Doc) => Promise<Doc>;
+  putItem: (params: Doc, options?: Doc) => Promise<Doc>;
+  restoreTableFromBackup: (params: Doc, options?: Doc) => Promise<Doc>;
+  restoreTableToPointInTime: (params: Doc, options?: Doc) => Promise<Doc>;
+  tagResource: (params: Doc, options?: Doc) => Promise<Doc>;
+  transactGetItems: (params: Doc, options?: Doc) => Promise<Doc>;
+  transactWriteItems: (params: Doc, options?: Doc) => Promise<Doc>;
+  untagResource: (params: Doc, options?: Doc) => Promise<Doc>;
+  updateContinuousBackups: (params: Doc, options?: Doc) => Promise<Doc>;
+  updateGlobalTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  updateGlobalTableSettings: (params: Doc, options?: Doc) => Promise<Doc>;
+  updateItem: (params: Doc, options?: Doc) => Promise<Doc>;
+  updateTable: (params: Doc, options?: Doc) => Promise<Doc>;
+  updateTimeToLive: (params: Doc, options?: Doc) => Promise<Doc>;
 }
 
 /** Credentials. */
@@ -83,7 +113,11 @@ export function createClient(conf?: ClientConfig): DynamoDBClient {
   const dyno: DynamoDBClient = {} as DynamoDBClient;
 
   for (const op of OPS) {
-    dyno[camelCase(op)] = baseOp.bind(null, _conf, op);
+    if (op === "Query" || op === "Scan") {
+      dyno[camelCase(op)] = baseOpIterator.bind(null, _conf, op);
+    } else {
+      dyno[camelCase(op)] = baseOp.bind(null, _conf, op);
+    }
   }
 
   return dyno;


### PR DESCRIPTION
Fixes #4 

@chiefbiiko This also makes the DynamoDBClient interface more explicit... This would be a breaking change, but IMO it's a more user-friendly API.

---

If you wanted convenience functions for scan+query that return Promise<Doc> we can special case i.e.

```ts
  dyno.queryOne = async (params: Doc, options?: Doc): Promise<Doc> => {
   // TODO handle options === undefined
    options.iteratePages = false;
    for await (page of dyno.query(params, options)) {
      return page
    }
  }

  dyno.scanOne = async (params: Doc, options?: Doc): Promise<Doc> => {
    options.iteratePages = false;
    for await (page of dyno.scan(params, options)) {
      return page
    }
  }
```
(save for a future PR - naming is discussion worthy).