### PR TITLE
if provided, use a dynamodb host config in place of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ export interface ClientConfig {
   profile?: string; // default
   canonicalUri?: string; // fx /path/to/somewhere
   port?: number; // 80
+  host?: string; // localhost
 }
 
 /** Op options. */

--- a/client/derive_config.ts
+++ b/client/derive_config.ts
@@ -6,15 +6,14 @@ import { createCache } from "./create_cache.ts";
 /** Derives host and endpoint. */
 function deriveHostEndpoint(
   region: string,
-  port?: number,
-  host?: string
+  port = 8000,
+  host = "localhost"
 ): { host: string; endpoint: string } {
-  let _host: string;
+  let _host: string = host;
   let endpoint: string;
 
   if (region === "local") {
-    _host = host || "localhost";
-    endpoint = `http://${_host}:${port || 8000}/`;
+    endpoint = `http://${host}:${port}/`;
   } else {
     _host = `dynamodb.${region}.amazonaws.com`;
     endpoint = `https://${_host}:443/`;

--- a/client/derive_config.ts
+++ b/client/derive_config.ts
@@ -12,7 +12,7 @@ function deriveHostEndpoint(
   let endpoint: string;
 
   if (region === "local") {
-    host = "localhost";
+    host = Deno.env.get("DYNAMODB_HOST") || "localhost";
     endpoint = `http://${host}:${port || 8000}/`;
   } else {
     host = `dynamodb.${region}.amazonaws.com`;

--- a/client/derive_config.ts
+++ b/client/derive_config.ts
@@ -6,20 +6,21 @@ import { createCache } from "./create_cache.ts";
 /** Derives host and endpoint. */
 function deriveHostEndpoint(
   region: string,
-  port: number,
+  port?: number,
+  host?: string
 ): { host: string; endpoint: string } {
-  let host: string;
+  let _host: string;
   let endpoint: string;
 
   if (region === "local") {
-    host = Deno.env.get("DYNAMODB_HOST") || "localhost";
-    endpoint = `http://${host}:${port || 8000}/`;
+    _host = host || "localhost";
+    endpoint = `http://${_host}:${port || 8000}/`;
   } else {
-    host = `dynamodb.${region}.amazonaws.com`;
-    endpoint = `https://${host}:443/`;
+    _host = `dynamodb.${region}.amazonaws.com`;
+    endpoint = `https://${_host}:443/`;
   }
 
-  return { host, endpoint };
+  return { host: _host, endpoint };
 }
 
 /** Derives an internal config object from a ClientConfig. */
@@ -60,6 +61,6 @@ export function deriveConfig(conf: ClientConfig = {}): Doc {
     ..._conf,
     cache: createCache(_conf),
     method: "POST",
-    ...deriveHostEndpoint(_conf.region!, _conf.port!),
+    ...deriveHostEndpoint(_conf.region!, _conf.port!, _conf.host!),
   };
 }

--- a/mod.ts
+++ b/mod.ts
@@ -34,6 +34,7 @@ export interface ClientConfig {
   profile?: string; // default
   canonicalUri?: string; // fx /path/to/somewhere
   port?: number; // 80
+  host?: string; // localhost
 }
 
 /** DynamoDB operations. */

--- a/test/local.ts
+++ b/test/local.ts
@@ -6,6 +6,8 @@ import {
 
 import { ClientConfig, DynamoDBClient, createClient } from "../mod.ts";
 
+import { deriveConfig } from "../client/derive_config.ts";
+
 import { Doc } from "../util.ts";
 
 const TABLE_NAME: string = "testing_table";
@@ -32,6 +34,26 @@ if (!result.TableNames.includes(TABLE_NAME)) {
     ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
   });
 }
+
+Deno.test({
+  name: "sets specified dynamodb host",
+  async fn(): Promise<void> {
+    const _conf: ClientConfig = {
+      credentials: {
+        accessKeyId: "DynamoDBLocal",
+        secretAccessKey: "DoesNotDoAnyAuth",
+        sessionToken: "preferTemporaryCredentials",
+      },
+      region: "local",
+      port: 8000, // DynamoDB Local's default port
+      host: "host.docker.internal", // Specific DynamoDB host
+    };
+      
+    let result: Doc = deriveConfig(_conf);
+    
+    assertEquals(_conf.host, result.host);
+  },
+});
 
 Deno.test({
   name: "schema translation enabled by default",


### PR DESCRIPTION
It'd be quite handy to have the ability to specify a dynamodb host name in place of localhost, the use-case I have is running a deno app inside of a docker container that needs to connect to a local dynamodb running on the docker host machine.. so in this case I can set DYNAMODB_HOST=host.docker.internal and it'll make the connection properly.