### PR TITLE
Export type is required with --isolatedModules

### DIFF
--- a/client/create_headers.ts
+++ b/client/create_headers.ts
@@ -10,12 +10,14 @@ const ALGORITHM: string = "AWS4-HMAC-SHA256";
 const CONTENT_TYPE: string = "application/x-amz-json-1.0";
 
 /** Required configuration for assembling headers. */
-export interface HeadersConfig extends ClientConfig {
+interface HeadersConfig extends ClientConfig {
   host: string; // dynamodb.us-west-2.amazonaws.com
   method: string; // POST
   cache: Doc; // internal cache for expensive-2-make signing key (& credScope)
   date?: Date; // allows reusing a date for 5min (max signature timestamp diff)
 }
+
+export type { HeadersConfig };
 
 /** Assembles a header object for a DynamoDB request. */
 export async function createHeaders(

--- a/util.ts
+++ b/util.ts
@@ -2,9 +2,11 @@ const ANY_BUT_DIGITS: RegExp = /[^\d]/g;
 const ANY_BUT_DIGITS_T: RegExp = /[^\dT]/g;
 
 /** Generic document. */
-export interface Doc {
+interface Doc {
   [key: string]: any;
 }
+
+export type { Doc };
 
 /** noop. */
 export function noop(..._: any[]): void {}


### PR DESCRIPTION
Fixes #28.

As Deno turned on `--isolatedModules` flag by default, some interfaces required different exporting using `export type` instead of `export interface`.